### PR TITLE
Add in GlueXWriter

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -48,6 +48,7 @@ ROOT_GENERATE_DICTIONARY(G__${ELSPECTRO}
   Writer.h
   HepMC3Writer.h
   LundWriter.h
+  GlueXWriter.h
   EICSimpleWriter.h
   FunctionsForJpac.h
   Manager.h
@@ -97,6 +98,7 @@ add_library(${ELSPECTRO} SHARED
   Writer.cpp
   HepMC3Writer.cpp
   LundWriter.cpp
+  GlueXWriter.cpp
   EICSimpleWriter.cpp
   Manager.cpp
   FunctionsForJpac.cpp

--- a/core/ElSpectroLinkDef.h
+++ b/core/ElSpectroLinkDef.h
@@ -52,6 +52,7 @@
 
 #pragma link C++ class elSpectro::Writer+;
 #pragma link C++ class elSpectro::LundWriter+;
+#pragma link C++ class elSpectro::GlueXWriter+;
 #pragma link C++ class elSpectro::EICSimpleWriter+;
 #pragma link C++ class elSpectro::HepMC3Writer+;
 

--- a/core/GlueXWriter.cpp
+++ b/core/GlueXWriter.cpp
@@ -1,0 +1,92 @@
+#include "GlueXWriter.h"
+#include <iostream>
+
+namespace elSpectro{
+
+  ///Constructor to create ouput file and intialise data structures
+  GlueXWriter::GlueXWriter(const std::string &filename,long evPerFile, int runnumber):
+    _filename(filename),
+    _file(filename),
+    _eventsPerFile(evPerFile),
+    _runnumber(runnumber)
+  {
+    if(!_file.is_open()){
+      std::cerr<<"GlueXWriter::GlueXWriter file "<<filename<<" cannot be opened, exiting..."<<std::endl;
+      exit(0);
+    }
+ 
+  }
+  
+  GlueXWriter::~GlueXWriter(){
+    End();
+  }
+  ///////////////////////////////////////////////////////////////
+  ///Get beam and target, or e-/gamma and nucleus
+  void GlueXWriter::Init(){
+
+    Writer::Init();
+    //need to find e- and baryon
+    if(TDatabasePDG::Instance()->GetParticle(_initialParticles[0]->Pdg())->ParticleClass()==TString("Baryon") ){
+      _inTarget=_initialParticles[0];
+      _inBeam=_initialParticles[1]; 
+    }
+    else {
+      _inTarget=_initialParticles[1];
+      _inBeam=_initialParticles[0];
+    }
+ 
+    _beamPdg=_inBeam->Pdg();
+    _targetPdg=_inTarget->Pdg();
+  }
+  ///////////////////////////////////////////////////////////////
+  ///Close the file stream
+  void GlueXWriter::End(){
+    if(!_file.is_open()) return;
+    _file.close();
+
+  }
+  ///////////////////////////////////////////////////////////////
+  ///Reached max events for this file start another
+  void GlueXWriter::NewFile(){
+    End();
+    auto newfilename=TString(_filename);
+    newfilename.ReplaceAll(".dat",Form("__%d.dat",_nFile++));
+    _file.open(newfilename.Data());
+  }
+
+  /////////////////////////////////////////////////////////////
+  //write all the info required for this event
+  void GlueXWriter::FillAnEvent(){
+     
+    ////fill _stream
+    StreamEventInfo();
+ 
+    _id=1;//reset particle ID counter
+ 
+   
+    //final particles
+    int final_status=1;
+    for(const auto* p:_finalParticles){
+     
+      StreamParticle(p,final_status);
+  
+     }
+      
+    _nEvent++;
+    
+    if(_nEvent%_eventsPerFile==0)
+      NewFile();
+  }
+
+  /////////////////////////////////////////////////////////
+ 
+  /////////////////////////////////////////////////////////
+  void GlueXWriter::Write(){
+    //write stream
+    _file<<_stream.rdbuf();
+    //reset stream
+    _stream.clear();
+  }
+
+ 
+}

--- a/core/GlueXWriter.h
+++ b/core/GlueXWriter.h
@@ -1,0 +1,83 @@
+//////////////////////////////////////////////////////////////
+///
+///Class:		GlueXWriter
+///Description:
+///             Instance of Writer for Lund format
+
+#pragma once
+
+#include "Writer.h"
+#include <TDatabasePDG.h>
+#include <string>
+#include <fstream>
+#include <sstream>
+
+namespace elSpectro{
+
+  class GlueXWriter : public Writer {
+
+     
+     
+     GlueXWriter()=default;
+     //don't want default contructor accessible
+     //only declaring default constructor
+     //so other 5 constructors also defaulted(rule of 5)
+
+   public:
+     GlueXWriter(const std::string& filename,long evPerFile=1E18, int runnumber=72068);
+     ~GlueXWriter() final;
+     GlueXWriter(const GlueXWriter& other); //need the virtual destructor...so rule of 5
+     GlueXWriter(GlueXWriter&&)=default;
+     GlueXWriter& operator=(const GlueXWriter& other);
+     GlueXWriter& operator=(GlueXWriter&& other) = default;
+     
+     void WriteHeader() final{};
+     void FillAnEvent() final;
+     void Write() final;
+     void End() final;
+     void Init() final;
+     void NewFile();
+     
+   private:
+     //streaming functions
+     // output genr8 data format which can then be converted to hddm with genr8_2_hddm
+     void StreamEventInfo(){
+       // Header (Event Info):
+       // run number, event number (start counting at 1), # of Particles
+  
+       _stream<< _runnumber << " " << _nEvent+1 << " " <<_finalParticles.size()<<"\n";
+     }
+     void StreamParticle(const Particle* p,int status){
+       // index, PID, mass
+       // charge, P.x, P.y, P.z, E
+       auto p4=p->P4();
+       int geantCode = TDatabasePDG::Instance()->ConvertPdgToGeant3(p->Pdg());
+       int charge = TDatabasePDG::Instance()->GetParticle(p->Pdg())->Charge()/3;
+       _stream<<_id++<<" "<<geantCode<<" "<<p4.M()<<"\n"
+	      <<"\t"<< charge <<" "<<p4.X()<<" "<<p4.Y()<<" "<<p4.Z()<<" "<<p4.T()<<"\n";
+     }
+   
+     //data members
+     std::ofstream _file; //! output file
+     //std::ostream _stream; //! output stream
+     std::stringstream _stream;
+     std::string _filename;
+     
+     long _nEvent={0};
+     int _nFile={1};
+     long _eventsPerFile=static_cast<long>(1E18);
+     int _runnumber=72068;
+     
+     int _id=1;
+     int _beamPdg=0;
+     int _targetPdg=0;
+     
+     const Particle* _inBeam={nullptr};
+     const Particle* _inTarget={nullptr};
+     
+     ClassDef(elSpectro::GlueXWriter,1); //class Writer
+   };
+
+
+}
+


### PR DESCRIPTION
The GlueXWriter outputs the data in a simple format used by the genr8 event generator. This can then be easily converted to hddm with a GlueX tool (genr8_2_hddm). The advantage is that this doesn't introduce any new dependencies for elSpectro.